### PR TITLE
In service section when we hover on last two cards text is not visible

### DIFF
--- a/Css-files/content.css
+++ b/Css-files/content.css
@@ -318,6 +318,9 @@ div.deals:hover{
   color: brown !important;
 }
 
+.deals:hover p a{
+  color: brown !important;
+}
 .deals p{
   font-size: 1.1rem;
   padding-top: 2px;

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -179,6 +179,15 @@ body{
         transform: rotate(360deg);
     }
 }
+
+.deals:hover {
+    background-color: hsl(203, 30%, 95%); /* Optional: change background on hover */
+}
+
+.deals:hover p {
+    color: hsl(203, 30%, 50%); /* Change to a darker color for contrast on hover */
+ color: hsl(203, 30%, 50%); 
+}
     </style>
 
 </head>
@@ -387,7 +396,7 @@ body{
             <div class="second_cont" style="font-family: Garamond;">
                 <div class="deals">
                     <i class="fa-solid fa-gift"></i>
-                    <p
+                    <p class="dealsp"
                         style="font-family: var(--ff-philosopher);color: hsl(203, 30%, 26%);"><a
                             href="./payment2.html"
                             style="text-decoration: none;color: black;">Gift
@@ -395,7 +404,7 @@ body{
                 </div>
                 <div class="deals">
                     <i class="fa-solid fa-ticket"></i>
-                    <p
+                    <p class="dealsp"
                         style="font-family: var(--ff-philosopher);color: hsl(203, 30%, 26%);"><a
                             href="./payment2.html"
                             style="text-decoration: none;color: black;">Exclusive


### PR DESCRIPTION
<!-- ISSUE & PR TITLE SHOULD BE SAME-->
In service section when we hover on last two cards text is not visible
## Description
<!--Please include a brief description of the changes-->
Describe the bug
The bug occurs when hovering over the last two cards in the services section. The text on these cards is white, and the hover background color is also white, causing the text to become invisible or hard to read due to the lack of contrast. This results in a poor user experience, as the text essentially disappears during the hover state.

Expected behavior
The expected behavior is that when hovering over the last two cards in the services section, the text should remain clearly visible and easily readable. Ideally, the text color should either change to a contrasting color or the hover background color should be adjusted to ensure sufficient contrast between the text and the background. This would maintain readability and improve the user experience.

## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
None
- Closes #220 

## Type of PR
<!-- Mention PR Type according to the issue in brackets below and check the below box -->
- [ ] ()

## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
![Screenshot (6)](https://github.com/user-attachments/assets/e9efb575-62fb-4505-bdf2-df42fafd0082)


## Checklist
<!-- [X] - put a cross/X inside [] to check the box -->
- [X ] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X ] I have updated my branch and synced it with project `main` branch before making this PR
- [X ] I have performed a self-review of my code
- [X ] I have tested the changes thoroughly before submitting this pull request.
- [X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X ] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->
