### PR TITLE
Follow Us social media icons aren't looking right on about page

### DIFF
--- a/Css-files/about.css
+++ b/Css-files/about.css
@@ -341,46 +341,6 @@
     /* color: white; */
   }
   
-  .fa-facebook{
-    color: hsl(203, 30%, 26%);
-    font-size: 1.2rem;
-    padding: 8px;
-    margin: 15px;
-  }
-  
-  .fa-facebook:hover {
-    
-    transform: scale(1.5);
-    color:#3B5998;
-    transition: transform 0.2s ease, color 0.2s ease;
-  }
-  
-  .fa-instagram{
-    color: hsl(203, 30%, 26%);
-    font-size: 1.2rem;
-    padding: 8px;
-    margin: 15px;
-  }
-  .fa-instagram:hover {
-    transform: scale(1.5);
-    color:#D62976;
-    transition: transform 0.2s ease, color 0.2s ease;
-  }
-  .fa-x-twitter{
-    color: hsl(203, 30%, 26%);
-    font-size: 1.2rem;
-    padding: 8px;
-    margin: 15px;
-  
-  }
-  
-  .fa-x-twitter:hover {
-    color:black;
-    transform: scale(1.5);
-    transition: transform 0.2s ease, color 0.2s ease;
-  }
-  
-  
   .foot_panel4{
     background-color: transparent;
     /* color:hsl(203, 30%, 26%); */


### PR DESCRIPTION
this fixes #353 
<!-- ISSUE & PR TITLE SHOULD BE SAME-->
## Description
Cleaned the styling of icons, which is no longer applicable to the icons under the 'Follow Us' section on the About page. (the original issue had been resolved so I removed the styling not in use anymore)

## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #353 

## Type of PR
<!-- Mention PR Type according to the issue in brackets below and check the below box -->
- [X] 🐞[bug] 


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->


## Checklist
<!-- [X] - put a cross/X inside [] to check the box -->
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->
