### PR TITLE
Fix:Move to top hover is not visible on hover.

### DIFF
--- a/Html-files/about.html
+++ b/Html-files/about.html
@@ -39,7 +39,7 @@ font-size: 18px;
 border: none;
 outline: none;
 background-color: transparent; 
-color: white; 
+color: #C4D7FF; 
 cursor: pointer; 
 padding: 15px; 
 border-radius: 4px; 
@@ -47,7 +47,7 @@ border-radius: 4px;
 
 #sr:hover {
 background-color: transparent; 
-color: black;
+color: #C4D7FF;
 border-radius: 100px;
 }
 .circle{
@@ -733,6 +733,15 @@ h1, h2, h3, h4, h5, h6 {
           <div class="footer_bg_two"></div>
         </div>
       </div>
+      <div>
+        <button id="sr" style="z-index: 1000; display: block;">
+        <div class="circle1">
+          <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+            <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"></path>
+          </svg>
+        </div>
+        </button>
+    </div>
     
       <!-- Footer Bottom -->
       <div class="footer_bottom">

--- a/Html-files/cart.html
+++ b/Html-files/cart.html
@@ -123,7 +123,7 @@
       border: none;
       outline: none;
       background-color: transparent;
-      color: white;
+      color: #87A2FF;
       cursor: pointer;
       padding: 15px;
       border-radius: 4px;
@@ -131,7 +131,7 @@
 
     #sr:hover {
       background-color: transparent;
-      color: black;
+      color: #C4D7FF;
       border-radius: 100px;
     }
 

--- a/Html-files/contact.html
+++ b/Html-files/contact.html
@@ -47,7 +47,7 @@
             border: none;
             outline: none;
             background-color: transparent;
-            color: white;
+            color: #87A2FF;
             cursor: pointer;
             padding: 15px;
             border-radius: 4px;
@@ -55,7 +55,7 @@
 
         #sr:hover {
             background-color: transparent;
-            color: black;
+            color: #C4D7FF;
             border-radius: 100px;
         }
 
@@ -325,7 +325,7 @@
         <style>
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');  
             @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');  
-#sr {
+/* #sr {
 display: none; 
 position: fixed; 
 bottom: 20px; 
@@ -339,13 +339,13 @@ color: white;
 cursor: pointer; 
 padding: 15px; 
 border-radius: 4px; 
-}
+} */
 
-#sr:hover {
+/* #sr:hover {
 background-color: transparent; 
 color: black;
 border-radius: 100px;
-}
+} */
     .circle{
        z-index: 10000;
        width: 20px;

--- a/Html-files/menu.html
+++ b/Html-files/menu.html
@@ -85,7 +85,7 @@ font-size: 18px;
 border: none;
 outline: none;
 background-color: transparent; 
-color: white; 
+color: #87A2FF; 
 cursor: pointer; 
 padding: 15px; 
 border-radius: 4px; 
@@ -93,7 +93,7 @@ border-radius: 4px;
 
 #sr:hover {
 background-color: transparent; 
-color: black;
+color: #C4D7FF;
 border-radius: 100px;
 }
 .circle{

--- a/Html-files/services.html
+++ b/Html-files/services.html
@@ -47,7 +47,7 @@ font-size: 18px;
 border: none;
 outline: none;
 background-color: transparent; 
-color: white; 
+color: #87A2FF; 
 cursor: pointer; 
 padding: 15px; 
 border-radius: 4px; 
@@ -55,7 +55,7 @@ border-radius: 4px;
 
 #sr:hover {
 background-color: transparent; 
-color: black;
+color: #C4D7FF;
 border-radius: 100px;
 }
 .circle{

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@ font-size: 18px;
 border: none;
 outline: none;
 background-color: transparent; 
-color: white; 
+color: #87A2FF;  /*Color without hover*/
 cursor: pointer; 
 padding: 15px; 
 border-radius: 4px; 
@@ -188,7 +188,7 @@ border-radius: 4px;
 
 #sr:hover {
 background-color: transparent; 
-color: black;
+color: #C4D7FF;  /*Color on hover*/
 border-radius: 100px;
 }
 .circle{


### PR DESCRIPTION
<!-- ISSUE & PR TITLE SHOULD BE SAME-->
## Description
<!--Please include a brief description of the changes-->
Hover on move to top button was not visible and at the bottom the button was not visible due to white color.
I had changed the color of Move to top button on both normal and on hover.

## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #455 

## Type of PR
<!-- Mention PR Type according to the issue in brackets below and check the below box -->
- [X] (#455)

## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
![image](https://github.com/user-attachments/assets/76b33e9e-35da-4481-9d11-0123f3380641)
![image](https://github.com/user-attachments/assets/9eefba57-2137-4be3-b895-ae478f3ec018)


## Checklist
<!-- [X] - put a cross/X inside [] to check the box -->
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->


@Anjaliavv51 please review it and merge it.