### PR TITLE
chore: remove the stretching of images on services page

### DIFF
--- a/Css-files/content.css
+++ b/Css-files/content.css
@@ -371,6 +371,8 @@ div.deals:hover{
   height:100px;
   border-radius:50%;
   margin:0 auto 1.5rem;
+  object-fit: cover;
+  object-position: 55% 0%;
 }
 .testimonal__title{
   margin-bottom: .75rem;


### PR DESCRIPTION
**🐞[bug]: Fixing the images on services page**
## Description
I have only fixed the problem of images being squeezed and stretched on the Services page by only adding the object-fit: cover; and object-position property in CSS for the images.


## Related Issues
None

- Closes issue# 461

## Type of PR

- [X ] (It's basically a UI change on the Services page only)

## Screenshots / videos (if applicable)
![Screenshot (656)](https://github.com/user-attachments/assets/caf54aab-9abb-4197-8d44-7e6c3f798475)
Now the image looks great. It's not stretched or squeezed now.


## Checklist
- [X ] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
You can compare the screenshot in the issue and the screenshot provided here. Now the bug is resolved.
Waiting for this PR to be merged soon.