### PR TITLE
made menu items cards more responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -391,7 +391,11 @@ body {
 }
 
 .menu_items {
+  width: 100px;
+  height: 100px;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   overflow: hidden;
 }
 


### PR DESCRIPTION
<!-- ISSUE & PR TITLE SHOULD BE SAME-->
## Description
The menu items on the home page were not responsive. I have attached the video demonstrating before and after adding responsiveness to the menu items cards.


## Related Issues

None
- Closes #

## Type of PR
- [X] (Responsiveness)

## Screenshots / videos (if applicable)
This is the previous responsiveness of the cards :
https://github.com/user-attachments/assets/28a1494f-0b48-4514-bab7-ba2b500a286d

This is the updated responsiveness :
https://github.com/user-attachments/assets/31e05680-5d4c-436f-b214-4cd7bf5a5b76


## Checklist
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
I have made minor changes in the style.css where in the class menu_items, I added flex-wrap to flexbox, added justify-content to the center, and changed the padding and height of the items. 
