### PR TITLE
justified-the-content-of-the-signup-page-evenly

### DIFF
--- a/Css-files/signup1.css
+++ b/Css-files/signup1.css
@@ -29,11 +29,11 @@ body {
 
 .main-login {
   display: flex;
-  justify-content: center;
   align-items: center;
   width: 100%;
   overflow: hidden; /* Ensure nothing overflows from the flexbox */
   gap: 20px; /* Spacing between the card and image */
+  justify-content: space-evenly;
   
 }
 .homebtn{


### PR DESCRIPTION
<!-- ISSUE & PR TITLE SHOULD BE SAME-->
## Description

There isn't any space between "Retro Vibe is good vibe" and signup card and also the "Retro Vibe is good vibe" card isn't aligned to the center.
<!--Please include a brief description of the changes-->
## Changes made

Aligned the contents of the page evenly so when the mouse pointer hovers over "Retro Vibe is good vibe" and signup card, there is space and the page looks good with even alignment.


## Related Issues

None

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #490

## Type of PR
<!-- Mention PR Type according to the issue in brackets below and check the below box -->
- [ ] ()

## Screenshots / videos (if applicable)

![image](https://github.com/user-attachments/assets/da979d58-de81-4f83-a200-2d2c0615e25b)

<!--Attach any relevant screenshots or videos demonstrating the changes-->


## Checklist
<!-- [X] - put a cross/X inside [] to check the box -->
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->
