### PR TITLE
Navbar background scrolling on home page #841

### DIFF
--- a/Css-files/navbarstyles.css
+++ b/Css-files/navbarstyles.css
@@ -143,6 +143,13 @@ body {
     color: #d2691e;
 }
 
+/* Add these styles for mobile menu */
+body.menu-open {
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
+}
+
 /* Mobile Styles */
 @media (max-width: 768px) {
     .navbar-brand {
@@ -163,5 +170,27 @@ body {
 
     .nav-item {
         margin-bottom: 1rem;
+    }
+
+    .navbar-collapse {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(255, 255, 245, 0.95);
+        padding: 80px 20px 20px;
+        overflow-y: auto;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease-in-out;
+        z-index: 1029;
+    }
+
+    .navbar-collapse.show {
+        transform: translateX(0);
+    }
+
+    .navbar-nav {
+        height: 100%;
     }
 }

--- a/index.html
+++ b/index.html
@@ -587,7 +587,38 @@ p {
 
 document.body.classList.add('light-mode');
 
+document.addEventListener('DOMContentLoaded', function() {
+    const hamburger = document.querySelector('.navbar-toggler');
+    const navLinks = document.querySelectorAll('.nav-link');
+    const body = document.body;
+    const navbarCollapse = document.querySelector('.navbar-collapse');
+    
+    // Existing hamburger click handler
+    hamburger.addEventListener('click', function() {
+        if (this.getAttribute('aria-expanded') === 'true') {
+            body.classList.add('menu-open');
+        } else {
+            body.classList.remove('menu-open');
+        }
+    });
 
+    // Add click handler for nav links
+    navLinks.forEach(link => {
+        link.addEventListener('click', function() {
+            if (navbarCollapse.classList.contains('show')) {
+                hamburger.click(); // Simulate click on hamburger to close menu
+            }
+        });
+    });
+
+    // Close menu when clicking outside
+    document.addEventListener('click', function(e) {
+        const navbar = document.querySelector('.navbar');
+        if (!navbar.contains(e.target) && navbarCollapse.classList.contains('show')) {
+            hamburger.click();
+        }
+    });
+    });
 </script>
     <!--Navbar End-->
 


### PR DESCRIPTION
## Description

This pull request addresses the mobile navigation experience for the website. Specifically, it introduces enhancements to improve usability and ensure a more seamless interaction for users. Key changes include:

1. Adding functionality to close the menu when a navigation link is clicked or when the user clicks outside the menu area.
2. Preventing the body from scrolling when the mobile menu is open by applying the menu-open class.
3. Enhancing the appearance and behavior of the mobile navigation menu with smooth transitions and a full-page overlay effect.

## Related Issues
“None”

- Closes #841

## Type of PR
- [X] Bug Fixes
- [X] Extra one functionality

## Checklist
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [x] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.