### PR TITLE
feat: implement PR title checker workflow for conventional commit prefixes

### DIFF
--- a/.github/pr-title-checker.json
+++ b/.github/pr-title-checker.json
@@ -1,0 +1,25 @@
+{
+    "LABEL": {
+      "name": "title needs formatting",
+      "color": "F9D0C4"
+    },
+    "CHECKS": {
+      "prefixes": [
+        "build: ",
+        "chore: ",
+        "docs: ",
+        "feat: ",
+        "fix: ",
+        "perf: ",
+        "refactor: ",
+        "revert: ",
+        "style: ",
+        "test: "
+      ]
+    },
+    "MESSAGES": {
+      "success": "Everything is great. Status: 200",
+      "failure": "PR title does not conform to the required format. Please use one of the specified prefixes followed by a colon and a space. Status: 400",
+      "notice": ""
+    }
+  }

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,19 @@
+name: 'PR Title Checker'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.7
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: '.github/pr-title-checker.json'


### PR DESCRIPTION
## Related Issues
- Closes #883 

## Description
This pull request addresses the need for a PR title checker to ensure conformity to conventional commit prefixes. The specified prefixes include `build`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, and `test`. Consistent PR titles are essential for maintaining clarity and organization in the project's version history.

### Files added
- `.github/pr-title-checker.json`
- `.github/workflows/pr-title-checker.yml`

### Solution:
1. Developed a PR title checker script to validate titles against the defined prefixes.
2. Integrated the checker into the project's CI/CD pipeline for automatic validation.
3. Defined clear error messages for non-compliant PR titles, aiding contributors in adhering to guidelines.

### To-Do:
- [x] Develop and test the PR title checker script.
- [x] Integrate the checker into the CI/CD pipeline.
- [x] Define error messages for non-compliant PR titles.

This PR enhances the project's contribution guidelines by automating the validation of PR titles, ensuring adherence to conventional commit prefixes. Contributions and feedback are encouraged for continuous improvement.

## Checklist
<!-- [X] - put a cross/X inside [] to check the box -->
- [X] I have gone through the [contributing guide](https://github.com/Anjaliavv51/Retro)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.


